### PR TITLE
Fix the 'doesUserExist' function from accepting empty string

### DIFF
--- a/app/auth/fakeServer.js
+++ b/app/auth/fakeServer.js
@@ -100,7 +100,7 @@ let server = {
  * @param  {string} username The username that should be checked
  */
   doesUserExist (username) {
-    return !(users[username] === undefined)
+    return !(username in users)
   }
 }
 


### PR DESCRIPTION
This function would previously accept an empty field rather than returning false.
