### PR TITLE
delete useless code

### DIFF
--- a/app/sagas/index.js
+++ b/app/sagas/index.js
@@ -105,12 +105,6 @@ export function * loginFlow () {
       yield put({type: SET_AUTH, newAuthState: true}) // User is logged in (authorized)
       yield put({type: CHANGE_FORM, newFormState: {username: '', password: ''}}) // Clear form
       forwardTo('/dashboard') // Go to dashboard page
-      // If `logout` won...
-    } else if (winner.logout) {
-      // ...we send Redux appropiate action
-      yield put({type: SET_AUTH, newAuthState: false}) // User is not logged in (not authorized)
-      yield call(logout) // Call `logout` effect
-      forwardTo('/') // Go to root page
     }
   }
 }


### PR DESCRIPTION
even if while authorizing we received logout request, we make logout actions twice:

yield put({type: SET_AUTH, newAuthState: false})
yield call(logout)
forwardTo('/')

so, one of this deleted.