### PR TITLE
delete useless code

### DIFF
--- a/app/sagas/index.js
+++ b/app/sagas/index.js
@@ -105,12 +105,6 @@ export function * loginFlow () {
       yield put({type: SET_AUTH, newAuthState: true}) // User is logged in (authorized)
       yield put({type: CHANGE_FORM, newFormState: {username: '', password: ''}}) // Clear form
       forwardTo('/dashboard') // Go to dashboard page
-      // If `logout` won...
-    } else if (winner.logout) {
-      // ...we send Redux appropiate action
-      yield put({type: SET_AUTH, newAuthState: false}) // User is not logged in (not authorized)
-      yield call(logout) // Call `logout` effect
-      forwardTo('/') // Go to root page
     }
   }
 }

--- a/test/sagas.js
+++ b/test/sagas.js
@@ -38,32 +38,6 @@ test('loginFlow saga with success', t => {
   )
 })
 
-test('loginFlow saga with logout as race winner', t => {
-  let gen = loginFlow()
-  let loginRace = race(raceObject)
-  let logOutWinner = {logout: true}
-
-  t.deepEqual(
-    gen.next().value,
-    take(constants.LOGIN_REQUEST)
-  )
-
-  t.deepEqual(
-    gen.next(data).value,
-    loginRace
-  )
-
-  t.deepEqual(
-    gen.next(logOutWinner).value,
-    put(actions.setAuthState(false))
-  )
-
-  t.deepEqual(
-    gen.next().value,
-    call(logout)
-  )
-})
-
 test('logoutFlow saga', t => {
   let gen = logoutFlow()
 


### PR DESCRIPTION
even if while authorizing we received logout request, we make logout actions twice:

yield put({type: SET_AUTH, newAuthState: false})
yield call(logout)
forwardTo('/')

so, one of this deleted.